### PR TITLE
Version 1.1.1.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,5 @@
 # Version 1.1.1.0
 
 - Fixed a bug where `--raw` was not respected in 1 request workflows
-- [ ] content size metrics are no longer IQR filtered, outliers in content size could require manual inspection so alerting for them is a good idea.
-- [ ] implemented much more efficient SIMD optimized implementation for summary calculations
+- Content size metrics are no longer IQR filtered, outliers in content size could require manual inspection so alerting for them is a good idea.
+- Implemented much more efficient SIMD optimized implementation for summary calculations

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,16 +1,5 @@
-# Versions 1.1.0.0 - 1.1.1.0
+# Version 1.1.1.0
 
-- Export styling was reworked for much prettier ui
-- Optimized interlocking variables to match hardware cache line size and reduce thread contention
-- Optimized tasks creation to increase maximum concurrency level
-- Enhanced styling of verbose progress reporting
-- Stabilized and improved concurrency tracking in the face of exceptions
-- Added `--raw` option to exports (skips creating a custom html)
-  - this option can be combined with `--json` to format the content as json
-  - this option will also change the file extension to `json` when the flag is used or if it is an exception
-- `terms-of-use` is now a command, not a flag
-- When `-n` (amount of requests) is set to 1, verbose output will be enforced for better readability
-- The changelog for the versions will now be the body of each release
-- Updated internals to watch for different values in remote to track updates
-  - This means that previous versions will not be able to track (>=1.1.0.0) updates
-- Summary will now filter out latency and size IQR outliers
+- Fixed a bug where `--raw` was not respected in 1 request workflows
+- [ ] content size metrics are no longer IQR filtered, outliers in content size could require manual inspection so alerting for them is a good idea.
+- [ ] implemented much more efficient SIMD optimized implementation for summary calculations

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-# Version 1.1.0.0
+# Versions 1.1.0.0 - 1.1.1.0
 
 - Export styling was reworked for much prettier ui
 - Optimized interlocking variables to match hardware cache line size and reduce thread contention

--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.1.1.0
+
+- Fixed a bug where `--raw` was not respected in 1 request workflows
+
 ## Version 1.1.0.0
 
 - Export styling was reworked for much prettier ui

--- a/History.md
+++ b/History.md
@@ -3,6 +3,8 @@
 ## Version 1.1.1.0
 
 - Fixed a bug where `--raw` was not respected in 1 request workflows
+- Content size metrics are no longer IQR filtered, outliers in content size could require manual inspection so alerting for them is a good idea.
+- Implemented much more efficient SIMD optimized implementation for summary calculations
 
 ## Version 1.1.0.0
 

--- a/src/Pulse/Core/PulseSummary.cs
+++ b/src/Pulse/Core/PulseSummary.cs
@@ -243,7 +243,7 @@ public sealed class PulseSummary {
 		Exporter.ClearFiles(directory);
 
 		if (count is 1) {
-			await Exporter.ExportHtmlAsync(uniqueRequests.First(), directory, Parameters.FormatJson, token);
+			await Exporter.ExportResponseAsync(uniqueRequests.First(), directory, Parameters, token);
 			WriteLine(["1" * Color.Cyan, $" unique response exported to ", Parameters.OutputFolder * Color.Yellow, " folder"]);
 			return;
 		}

--- a/src/Pulse/Core/PulseSummary.cs
+++ b/src/Pulse/Core/PulseSummary.cs
@@ -3,6 +3,7 @@ using static PrettyConsole.Console;
 using PrettyConsole;
 using Pulse.Configuration;
 using Sharpify;
+using System.Numerics;
 
 namespace Pulse.Core;
 
@@ -90,9 +91,9 @@ public sealed class PulseSummary {
 				ClearNextLines(3, OutputPipe.Out);
 			}
 
-            static string Outliers(int n) => n is 1 ? "outlier" : "outliers";
+			static string Outliers(int n) => n is 1 ? "outlier" : "outliers";
 
-            WriteLine(["Request count: ", $"{completed}" * Color.Yellow]);
+			WriteLine(["Request count: ", $"{completed}" * Color.Yellow]);
 			WriteLine(["Concurrent connections: ", $"{peakConcurrentConnections}" * Color.Yellow]);
 			WriteLine(["Total duration: ", Utils.DateAndTime.FormatTimeSpan(Result.TotalDuration) * Color.Yellow]);
 			WriteLine(["Success Rate: ", $"{Result.SuccessRate}%" * Helper.GetPercentageBasedColor(Result.SuccessRate)]);
@@ -222,6 +223,26 @@ public sealed class PulseSummary {
 		public double Max;
 		public double Avg;
 		public int Removed;
+	}
+
+	internal static double Sum(ReadOnlySpan<double> span) {
+		double sum = 0;
+		int vectorSize = Vector<double>.Count;
+		int i = 0;
+
+		// Process data in chunks of vectorSize
+		while (i <= span.Length - vectorSize) {
+			var vector = new Vector<double>(span.Slice(i, vectorSize));
+			sum += Vector.Dot(vector, Vector<double>.One);
+			i += vectorSize;
+		}
+
+		// Process remaining elements
+		for (; i < span.Length; i++) {
+			sum += span[i];
+		}
+
+		return sum;
 	}
 
 	/// <summary>

--- a/src/Pulse/Core/SendCommand.cs
+++ b/src/Pulse/Core/SendCommand.cs
@@ -230,6 +230,7 @@ public sealed class SendCommand : Command {
 		if (parameters.ExecutionMode is ExecutionMode.Parallel && parameters.MaxConnectionsModified) {
 			WriteLine(["  Maximum concurrent connections: " * property, $"{parameters.MaxConnections}" * value]);
 		}
+		WriteLine(["  Export Raw: " * property, $"{parameters.ExportRaw}" * value]);
 		WriteLine(["  Format JSON: " * property, $"{parameters.FormatJson}" * value]);
 		WriteLine(["  Export Full Equality: " * property, $"{parameters.UseFullEquality}" * value]);
 		WriteLine(["  Export: " * property, $"{parameters.Export}" * value]);

--- a/src/Pulse/Program.cs
+++ b/src/Pulse/Program.cs
@@ -7,7 +7,7 @@ using static PrettyConsole.Console;
 using PrettyConsole;
 
 internal class Program {
-    internal const string VERSION = "1.1.0.0";
+    internal const string VERSION = "1.1.1.0";
 
     private static async Task<int> Main(string[] args) {
         using CancellationTokenSource globalCTS = new();

--- a/src/Pulse/Pulse.csproj
+++ b/src/Pulse/Pulse.csproj
@@ -15,7 +15,7 @@
     <AotCompatible>true</AotCompatible>
     <InvariantGlobalization>true</InvariantGlobalization>
     <StackTraceSupport>false</StackTraceSupport>
-    <Version>1.1.0.0</Version>
+    <Version>1.1.1.0</Version>
     <StripSymbols>true</StripSymbols>
     <RepositoryUrl>https://github.com/dusrdev/Pulse</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/tests/Pulse.Tests.Unit/SummaryTests.cs
+++ b/tests/Pulse.Tests.Unit/SummaryTests.cs
@@ -1,0 +1,54 @@
+using Pulse.Core;
+
+namespace Pulse.Tests.Unit;
+
+public class SummaryTests {
+    [Fact]
+    public void Summary_Sum_ReturnsCorrectValue() {
+        // Arrange
+        var arr = Enumerable.Range(0, 100).Select(_ => Random.Shared.NextDouble()).ToArray();
+        var expected = arr.Sum();
+
+        // Act
+        var actual = PulseSummary.Sum(arr);
+
+        // Assert
+        actual.Should().BeApproximately(expected, 0.01, "because the sum is correct");
+    }
+
+    [Theory]
+    [ClassData(typeof(SummaryTestData))]
+    public void GetSummary_TheoryTests(double[] values, bool removeOutliers, double expectedMin, double expectedMax, double expectedAvg, int expectedRemoved) {
+        // Act
+        var summary = PulseSummary.GetSummary(values, removeOutliers);
+
+        // Assert
+        summary.Min.Should().BeApproximately(expectedMin, 0.01, "because the min is correct");
+        summary.Max.Should().BeApproximately(expectedMax, 0.01, "because the max is correct");
+        summary.Avg.Should().BeApproximately(expectedAvg, 0.01, "because the avg is correct");
+        summary.Removed.Should().Be(expectedRemoved, "because the removed count is correct");
+    }
+
+    private class SummaryTestData : TheoryData<double[], bool, double, double, double, int> {
+        public SummaryTestData() {
+            // Test case 1: single element
+            Add([42], false, 42, 42, 42, 0);
+            // Test case 2: two elements without filtering
+            Add([10, 20], false, 10, 20, 15, 0);
+            // Test case 3: multiple elements without filtering
+            Add([1, 2, 3, 4, 5], false, 1, 5, 3, 0);
+            // Test case 4: multiple elements with outliers
+            Add([1, 2, 3, 4, 100], true, 1, 4, 2.5, 1);
+            // Test case 5: all elements identical without filtering
+            Add([5, 5, 5, 5], false, 5, 5, 5, 0);
+            // Test case 6: all elements identical with filtering
+            Add([5, 5, 5, 5], true, 5, 5, 5, 2);
+            // Test case 7: multiple outliers on both ends
+            Add([-10.0, 0.0, 1.0, 2.0, 3.0, 100.0], true, 0.0, 3.0, 1.5, 2);
+            // Test case 8: large dataset without outliers
+            Add(Enumerable.Range(1, 1000).Select(x => (double)x).ToArray(), true, 1.0, 1000.0, 500.5, 0);
+            // Test case 9: large dataset with outliers
+            Add(Enumerable.Range(1, 1000).Select(x => (double)x).Union([-1000.0, 2000.0]).ToArray(), true, 1.0, 1000.0, 500.5, 2);
+        }
+    }
+}


### PR DESCRIPTION
- Fixed a bug where `--raw` was not respected in 1 request workflows
- Content size metrics are no longer IQR filtered, outliers in content size could require manual inspection so alerting for them is a good idea.
- Implemented much more efficient SIMD optimized implementation for summary calculations