### PR TITLE
Version 1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ riderModule.iml
 /_ReSharper.Caches/
 /.idea
 .vscode
+._*

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- Raw export mode now outputs a special json with debug information for non-successful responses, it contains:
+- `--raw` export mode now outputs a special json with debug information for non-successful responses with no content, it contains:
   - Response status code as integer
   - Response headers
   - Response content (if any)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,6 @@
 # Changelog
 
-- Fixed parsing exception in cases where response charset contained redundant quotes like `\"utf-8\"`
-- Added support for AVX512
+- Raw export mode now outputs a special json with debug information for non-successful responses, it contains:
+  - Response status code as integer
+  - Response headers
+  - Response content (if any)

--- a/History.md
+++ b/History.md
@@ -2,7 +2,7 @@
 
 ## Version 1.2.0.0
 
-- Raw export mode now outputs a special json with debug information for non-successful responses, it contains:
+- `--raw` export mode now outputs a special json with debug information for non-successful responses with no content, it contains:
   - Response status code as integer
   - Response headers
   - Response content (if any)

--- a/History.md
+++ b/History.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Version 1.2.0.0
+
+- Raw export mode now outputs a special json with debug information for non-successful responses, it contains:
+  - Response status code as integer
+  - Response headers
+  - Response content (if any)
+
 ## Version 1.1.2.0
 
 - Fixed parsing exception in cases where response charset contained redundant quotes like `\"utf-8\"`

--- a/src/Pulse/Configuration/DefaultJsonContext.cs
+++ b/src/Pulse/Configuration/DefaultJsonContext.cs
@@ -16,7 +16,7 @@ namespace Pulse.Configuration;
 							 NumberHandling = JsonNumberHandling.AllowReadingFromString,
 							 WriteIndented = true,
 							 UseStringEnumConverter = true)]
-[JsonSerializable(typeof(IEnumerable<KeyValuePair<string, IEnumerable<string>>>))]
+[JsonSerializable(typeof(Dictionary<string, IEnumerable<string>>))]
 [JsonSerializable(typeof(RawFailure))]
 [JsonSerializable(typeof(StrippedException))]
 [JsonSerializable(typeof(ReleaseInfo))]
@@ -35,12 +35,6 @@ public partial class DefaultJsonContext : JsonSerializerContext {
 	}
 
 	/// <summary>
-	/// Serialize <see cref="RawFailure"/> to a string.
-	/// </summary>
-	/// <param name="failure"></param>
-	public static string Serialize(RawFailure failure) => JsonSerializer.Serialize(failure, Default.RawFailure);
-
-	/// <summary>
 	/// Serializes an exception to a string.
 	/// </summary>
 	/// <param name="e"></param>
@@ -53,4 +47,10 @@ public partial class DefaultJsonContext : JsonSerializerContext {
 	/// <param name="e"></param>
 	/// <returns></returns>
 	public static string SerializeException(StrippedException e) => JsonSerializer.Serialize(e, Default.StrippedException);
+
+	/// <summary>
+	/// Serialize <see cref="RawFailure"/> to a string.
+	/// </summary>
+	/// <param name="failure"></param>
+	public static string Serialize(RawFailure failure) => JsonSerializer.Serialize(failure, Default.RawFailure);
 }

--- a/src/Pulse/Configuration/DefaultJsonContext.cs
+++ b/src/Pulse/Configuration/DefaultJsonContext.cs
@@ -16,6 +16,8 @@ namespace Pulse.Configuration;
 							 NumberHandling = JsonNumberHandling.AllowReadingFromString,
 							 WriteIndented = true,
 							 UseStringEnumConverter = true)]
+[JsonSerializable(typeof(IEnumerable<KeyValuePair<string, IEnumerable<string>>>))]
+[JsonSerializable(typeof(RawFailure))]
 [JsonSerializable(typeof(StrippedException))]
 [JsonSerializable(typeof(ReleaseInfo))]
 public partial class DefaultJsonContext : JsonSerializerContext {
@@ -31,6 +33,12 @@ public partial class DefaultJsonContext : JsonSerializerContext {
 		}
 		return Result.Ok(remoteVersion);
 	}
+
+	/// <summary>
+	/// Serialize <see cref="RawFailure"/> to a string.
+	/// </summary>
+	/// <param name="failure"></param>
+	public static string Serialize(RawFailure failure) => JsonSerializer.Serialize(failure, Default.RawFailure);
 
 	/// <summary>
 	/// Serializes an exception to a string.

--- a/src/Pulse/Core/Exporter.cs
+++ b/src/Pulse/Core/Exporter.cs
@@ -34,7 +34,15 @@ public static class Exporter {
       content = DefaultJsonContext.SerializeException(result.Exception);
       extension = "json";
     } else {
-      if (formatJson) {
+      if (result.StatusCode is not HttpStatusCode.OK) {
+        var failure = new RawFailure {
+          StatusCode = (int)result.StatusCode,
+          Headers = result.Headers,
+          Content = result.Content
+        };
+        content = DefaultJsonContext.Serialize(failure);
+        extension = "json";
+      } else if (formatJson) {
         content = FormatJson(result.Content).Message;
         extension = "json";
       } else {

--- a/src/Pulse/Core/Exporter.cs
+++ b/src/Pulse/Core/Exporter.cs
@@ -21,7 +21,7 @@ public static class Exporter {
     }
   }
 
-  public static async Task ExportRawAsync(Response result, string path, bool formatJson = false, CancellationToken token = default) {
+  internal static async Task ExportRawAsync(Response result, string path, bool formatJson = false, CancellationToken token = default) {
     bool hasContent = result.Content.Length != 0;
 
     HttpStatusCode statusCode = result.StatusCode;
@@ -64,7 +64,8 @@ public static class Exporter {
       }
     }
   }
-  public static async Task ExportHtmlAsync(Response result, string path, bool formatJson = false, CancellationToken token = default) {
+
+  internal static async Task ExportHtmlAsync(Response result, string path, bool formatJson = false, CancellationToken token = default) {
     HttpStatusCode statusCode = result.StatusCode;
     string frameTitle;
     string content = string.IsNullOrWhiteSpace(result.Content) ? string.Empty : result.Content;

--- a/src/Pulse/Core/Exporter.cs
+++ b/src/Pulse/Core/Exporter.cs
@@ -22,9 +22,7 @@ public static class Exporter {
   }
 
   public static async Task ExportRawAsync(Response result, string path, bool formatJson = false, CancellationToken token = default) {
-    if (string.IsNullOrEmpty(result.Content) && result.Exception.IsDefault) {
-      return;
-    }
+    bool hasContent = result.Content.Length != 0;
 
     HttpStatusCode statusCode = result.StatusCode;
     string extension;
@@ -34,10 +32,10 @@ public static class Exporter {
       content = DefaultJsonContext.SerializeException(result.Exception);
       extension = "json";
     } else {
-      if (result.StatusCode is not HttpStatusCode.OK) {
+      if (result.StatusCode is not HttpStatusCode.OK && !hasContent) {
         var failure = new RawFailure {
           StatusCode = (int)result.StatusCode,
-          Headers = result.Headers,
+          Headers = result.Headers.ToDictionary(),
           Content = result.Content
         };
         content = DefaultJsonContext.Serialize(failure);

--- a/src/Pulse/Core/RawFailure.cs
+++ b/src/Pulse/Core/RawFailure.cs
@@ -1,0 +1,29 @@
+using Pulse.Configuration;
+
+namespace Pulse.Core;
+
+/// <summary>
+/// Represents a serializable way to display non successful response information when using <see cref="ParametersBase.ExportRaw"/>
+/// </summary>
+public readonly struct RawFailure {
+    public RawFailure() {
+		Headers = Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>();
+		StatusCode = 0;
+		Content = string.Empty;
+    }
+
+    /// <summary>
+    /// Response status code
+    /// </summary>
+    public int StatusCode { get; init; }
+
+	/// <summary>
+	/// Response headers
+	/// </summary>
+	public IEnumerable<KeyValuePair<string, IEnumerable<string>>> Headers { get; init; }
+
+	/// <summary>
+	/// Response content (if any)
+	/// </summary>
+	public string Content { get; init; } = string.Empty;
+}

--- a/src/Pulse/Core/RawFailure.cs
+++ b/src/Pulse/Core/RawFailure.cs
@@ -7,7 +7,7 @@ namespace Pulse.Core;
 /// </summary>
 public readonly struct RawFailure {
     public RawFailure() {
-		Headers = Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>();
+		Headers = [];
 		StatusCode = 0;
 		Content = string.Empty;
     }
@@ -20,7 +20,7 @@ public readonly struct RawFailure {
 	/// <summary>
 	/// Response headers
 	/// </summary>
-	public IEnumerable<KeyValuePair<string, IEnumerable<string>>> Headers { get; init; }
+	public Dictionary<string, IEnumerable<string>> Headers { get; init; }
 
 	/// <summary>
 	/// Response content (if any)

--- a/src/Pulse/Program.cs
+++ b/src/Pulse/Program.cs
@@ -7,7 +7,7 @@ using static PrettyConsole.Console;
 using PrettyConsole;
 
 internal class Program {
-    internal const string VERSION = "1.1.2.0";
+    internal const string VERSION = "1.2.0.0";
 
     private static async Task<int> Main(string[] args) {
         using CancellationTokenSource globalCTS = new();

--- a/src/Pulse/Pulse.csproj
+++ b/src/Pulse/Pulse.csproj
@@ -15,7 +15,7 @@
     <AotCompatible>true</AotCompatible>
     <InvariantGlobalization>true</InvariantGlobalization>
     <StackTraceSupport>false</StackTraceSupport>
-    <Version>1.1.2.0</Version>
+    <Version>1.2.0.0</Version>
     <StripSymbols>true</StripSymbols>
     <RepositoryUrl>https://github.com/dusrdev/Pulse</RepositoryUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
- `--raw` export mode now outputs a special json with debug information for non-successful responses with no content, it contains:
  - Response status code as integer
  - Response headers
  - Response content (if any)